### PR TITLE
feat: Support the obsidian.nvim community fork

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,5 +19,6 @@ ignore = {
 -- Global objects defined by the C code
 read_globals = {
   "vim",
+  "Obsidian",
   "MiniDoc",
 }

--- a/lua/obsidian-kensaku/picker.lua
+++ b/lua/obsidian-kensaku/picker.lua
@@ -185,9 +185,9 @@ end
 
 KensakuPicker._build_grep_cmd = function(self)
   local search = require "obsidian.search"
-  local search_opts = search.SearchOpts.from_tbl {
-    sort_by = self.client.opts.sort_by,
-    sort_reversed = self.client.opts.sort_reversed,
+  local search_opts = search.SearchOpts.as_tbl {
+    sort_by = Obsidian.opts.sort_by,
+    sort_reversed = Obsidian.opts.sort_reversed,
     smart_case = true,
   }
   return search.build_grep_cmd(search_opts)


### PR DESCRIPTION
The obsidian.nvim plugin has transitioned to a community fork, introducing breaking changes to its API. This commit updates the code to maintain compatibility.

- The method for creating search options has been changed from `SearchOpts.from_tbl` to `SearchOpts.as_tbl`.
- Plugin options are now retrieved from the global `Obsidian.opts` table instead of `client.opts`.